### PR TITLE
getNameByMessage refactored

### DIFF
--- a/src/EventListener/MessengerListener.php
+++ b/src/EventListener/MessengerListener.php
@@ -10,6 +10,7 @@ use OpenTracing\Tracer;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
 
 class MessengerListener
 {
@@ -46,6 +47,9 @@ class MessengerListener
 
         if ($span) {
             $span->setTag('messenger.transport', $event->getReceiverName());
+            /** @var BusNameStamp $busStamp */
+            $busStamp = $event->getEnvelope()->last(BusNameStamp::class);
+            $span->setTag('messenger.bus', $busStamp->getBusName());
             $span->finish();
         }
 

--- a/src/Service/RootSpanNameBuilder.php
+++ b/src/Service/RootSpanNameBuilder.php
@@ -10,7 +10,8 @@ use Adtechpotok\Bundle\SymfonyOpenTracing\Contract\GetSpanNameByRequest;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use function end;
+use function Symfony\Component\String\u;
 
 class RootSpanNameBuilder implements GetSpanNameByRequest, GetSpanNameByCommand, GetSpanNameByMessage
 {
@@ -60,8 +61,9 @@ class RootSpanNameBuilder implements GetSpanNameByRequest, GetSpanNameByCommand,
 
     public function getNameByMessage(Envelope $envelope): string
     {
-        /** @var BusNameStamp $busStamp */
-        $busStamp = $envelope->last(BusNameStamp::class);
-        return sprintf('%s.%s', $this->messageNamePrefix, $busStamp->getBusName());
+        $classParts = explode('\\', get_class($envelope->getMessage()));
+        $eventName = u(end($classParts))->camel();
+
+        return sprintf('%s.%s', $this->messageNamePrefix, $eventName);
     }
 }


### PR DESCRIPTION
message from outside of app (with custom serialization) doesn't have `BusNameStamp`,
that's why span root name refactored to resolve root span name from message class.